### PR TITLE
Adds libsasl2-dev to make provision work

### DIFF
--- a/cookbooks/vagrant_main/recipes/default.rb
+++ b/cookbooks/vagrant_main/recipes/default.rb
@@ -27,6 +27,7 @@ bash "debconf_for_phpmyadmin" do
   code "debconf-set-selections /tmp/phpmyadmin.deb.conf"
 end
 package "phpmyadmin"
+package "libsasl2-dev"
 
 # install the mongodb pecl
 php_pear "mongo" do


### PR DESCRIPTION
I was unable to run `vagrant up --provision` since I got this error message:

```
==> default: checking Build with PHP streams support... yes
==> default: checking Build with Cyrus SASL support... -e
==> default: checking for SASL... not found
==> default: configure: error: sasl.h not found!
==> default: ERROR: `/tmp/pear/temp/mongo/configure --with-mongo-sasl=-e' failed
==> default: STDERR:
==> default: ---- End output of echo -e "\r" | pecl -d preferred_state=stable install -a mongo ----
==> default: Ran echo -e "\r" | pecl -d preferred_state=stable install -a mongo returned 0
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```

Adding the package libsasl2-dev resolves the issue.
